### PR TITLE
Add explicit name to database index

### DIFF
--- a/lib/generators/altcha/install/templates/migrations/create_altcha_solutions.rb.erb
+++ b/lib/generators/altcha/install/templates/migrations/create_altcha_solutions.rb.erb
@@ -10,6 +10,6 @@ class CreateAltchaSolutions < ActiveRecord::Migration[<%= ActiveRecord::Migratio
       t.timestamps
     end
 
-    add_index :altcha_solutions, [ :algorithm, :challenge, :salt, :signature, :number ], unique: true
+    add_index :altcha_solutions, [ :algorithm, :challenge, :salt, :signature, :number ], unique: true, name: 'index_altcha_solutions'
   end
 end


### PR DESCRIPTION
We need to have an explicit name for the index as the auto-generated one is too long and fails (at least on postgres).

Closes zonque/altcha-rails#1